### PR TITLE
Trailing "," in functions parameters

### DIFF
--- a/library/index.js
+++ b/library/index.js
@@ -55,7 +55,7 @@ class AudioRecorder extends require(`events`).EventEmitter {
 				// Select default recording device if none specified, otherwise no continues recording.
 				if (process.platform === `win32` && !this.options.device) {
 					this.command.arguments.unshift(
-						`-d`,
+						`-d`
 					);
 				}
 			case `rec`:
@@ -92,7 +92,7 @@ class AudioRecorder extends require(`events`).EventEmitter {
 					if (this.options.keepSilence) {
 						this.command.arguments.push(
 							// Keep silence in results
-							`-l`,
+							`-l`
 						);
 					}
 					


### PR DESCRIPTION
There where 2 instances where there was an trailing comman in a function. This is not an issue in newer node versions. But I was using Node v6.17.1 where it was throwing errors

**Category**: 
`Code fix`

**Issue**: 
-

**Changes**: 
There where trailing comma's in 2 functions. Which is fine for modern Node. But for the version I was using v6.17.1 it was throwing errors



**Drawbacks**: 
There are none

**Checklist**: *Check off the box by placing a `x` inside the brackets after making sure you agree to the term outlined.*
* [X ] I have singed off my commits to adhere to the [Developer's Certificate of Origin](https://github.com/RedKenrok/node-audiorecorder/blob/master/DCO).